### PR TITLE
Add setup and run demos in travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+
+language: python
+
+python:
+ - "2.7"
+
+install:
+  - pip install -r requirements-py27-linux64.txt
+  - pip install -e .
+
+script:
+  - cd Demos; for f in *.py; do python $f; done 

--- a/Demos/demo1.py
+++ b/Demos/demo1.py
@@ -2,7 +2,7 @@
 MANUAL CREATION OF AN EARTHQUAKE DATABASE
 """
 
-import Catalogue as Cat
+from OQCatk import Catalogue as Cat
 Db = Cat.Database('First Test','NOTE: Just a test')
 
 L = [{'Year': 1960},

--- a/Demos/demo1.py
+++ b/Demos/demo1.py
@@ -2,7 +2,7 @@
 MANUAL CREATION OF AN EARTHQUAKE DATABASE
 """
 
-from OQCatk import Catalogue as Cat
+import OQCatk.Catalogue as Cat
 Db = Cat.Database('First Test','NOTE: Just a test')
 
 L = [{'Year': 1960},

--- a/Demos/demo2.py
+++ b/Demos/demo2.py
@@ -2,7 +2,7 @@
 DOWNLOADING ISC CATALOGUE
 """
 
-from OQCatk import IscWeb as Iw
+import OQCatk.IscWeb as Iw
 
 # Search Area
 lon = [-20, 60]

--- a/Demos/demo2.py
+++ b/Demos/demo2.py
@@ -2,7 +2,7 @@
 DOWNLOADING ISC CATALOGUE
 """
 
-import IscWeb as Iw
+from OQCatk import IscWeb as Iw
 
 # Search Area
 lon = [-20, 60]

--- a/Demos/demo3.py
+++ b/Demos/demo3.py
@@ -2,7 +2,7 @@
 EXAMPLE 3 - ISF CATALOGUE EXPLORATION
 """
 
-from OQCatk import Parsers as Par
+import OQCatk.Parsers as Par
 
 #-----------------------------------------------------------------------------------------
 # Isf parsing

--- a/Demos/demo3.py
+++ b/Demos/demo3.py
@@ -2,7 +2,7 @@
 EXAMPLE 3 - ISF CATALOGUE EXPLORATION
 """
 
-import Parsers as Par
+from OQCatk import Parsers as Par
 
 #-----------------------------------------------------------------------------------------
 # Isf parsing

--- a/Demos/demo4.py
+++ b/Demos/demo4.py
@@ -2,7 +2,7 @@
 EXAMPLE 4 - READING CSV CATALOGUE
 """
 
-import Catalogue as Cat
+from OQCatk import Catalogue as Cat
 
 #-----------------------------------------------------------------------------------------
 # 1) STANDARD FORMAT

--- a/Demos/demo4.py
+++ b/Demos/demo4.py
@@ -2,7 +2,7 @@
 EXAMPLE 4 - READING CSV CATALOGUE
 """
 
-from OQCatk import Catalogue as Cat
+import OQCatk.Catalogue as Cat
 
 #-----------------------------------------------------------------------------------------
 # 1) STANDARD FORMAT

--- a/Demos/demo5.py
+++ b/Demos/demo5.py
@@ -2,9 +2,9 @@
 EXAMPLE 5 - CATALOGUE MERGING
 """
 
-from OQCatk import Catalogue as Cat
-from OQCatk import Selection as Sel
-from OQCatk import MagRules as MR
+import OQCatk.Catalogue as Cat
+import OQCatk.Selection as Sel
+import OQCatk.MagRules as MR
 
 #-----------------------------------------------------------------------------------------
 # Import Catalogues

--- a/Demos/demo5.py
+++ b/Demos/demo5.py
@@ -2,9 +2,9 @@
 EXAMPLE 5 - CATALOGUE MERGING
 """
 
-import Catalogue as Cat
-import Selection as Sel
-import MagRules as MR
+from OQCatk import Catalogue as Cat
+from OQCatk import Selection as Sel
+from OQCatk import MagRules as MR
 
 #-----------------------------------------------------------------------------------------
 # Import Catalogues

--- a/Demos/demo6.py
+++ b/Demos/demo6.py
@@ -2,10 +2,10 @@
 EXAMPLE 6 - Area selection
 """
 
-import Catalogue as Cat
-import Exploration as Exp
-import MapTools as Map
-import CatUtils as Ct
+from OQCatk import Catalogue as Cat
+from OQCatk import Exploration as Exp
+from OQCatk import MapTools as Map
+from OQCatk import CatUtils as Ct
 
 #-----------------------------------------------------------------------------------------
 # Import catalogue

--- a/Demos/demo6.py
+++ b/Demos/demo6.py
@@ -2,10 +2,10 @@
 EXAMPLE 6 - Area selection
 """
 
-from OQCatk import Catalogue as Cat
-from OQCatk import Exploration as Exp
-from OQCatk import MapTools as Map
-from OQCatk import CatUtils as Ct
+import OQCatk.Catalogue as Cat
+import OQCatk.Exploration as Exp
+import OQCatk.MapTools as Map
+import OQCatk.CatUtils as Ct
 
 #-----------------------------------------------------------------------------------------
 # Import catalogue

--- a/Demos/demo7.py
+++ b/Demos/demo7.py
@@ -2,9 +2,9 @@
 EXAMPLE 7 - Prime analysis
 """
 
-import Parsers as Par
-import Exploration as Exp
-import MapTools as Map
+from OQCatk import Parsers as Par
+from OQCatk import Exploration as Exp
+from OQCatk import MapTools as Map
 
 #-----------------------------------------------------------------------------------------
 # Import catalogue

--- a/Demos/demo7.py
+++ b/Demos/demo7.py
@@ -2,9 +2,9 @@
 EXAMPLE 7 - Prime analysis
 """
 
-from OQCatk import Parsers as Par
-from OQCatk import Exploration as Exp
-from OQCatk import MapTools as Map
+import OQCatk.Parsers as Par
+import OQCatk.Exploration as Exp
+import OQCatk.MapTools as Map
 
 #-----------------------------------------------------------------------------------------
 # Import catalogue

--- a/Demos/demo8.py
+++ b/Demos/demo8.py
@@ -2,8 +2,8 @@
 EXAMPLE 8 - Sort catalogue
 """
 
-import Catalogue as Cat
-import Exploration as Exp
+from OQCatk import Catalogue as Cat
+from OQCatk import Exploration as Exp
 
 #-----------------------------------------------------------------------------------------
 # Import catalogue

--- a/Demos/demo8.py
+++ b/Demos/demo8.py
@@ -2,8 +2,8 @@
 EXAMPLE 8 - Sort catalogue
 """
 
-from OQCatk import Catalogue as Cat
-from OQCatk import Exploration as Exp
+import OQCatk.Catalogue as Cat
+import OQCatk.Exploration as Exp
 
 #-----------------------------------------------------------------------------------------
 # Import catalogue

--- a/Demos/demo9.py
+++ b/Demos/demo9.py
@@ -2,9 +2,9 @@
 EXAMPLE 9 - Parseing GCMT bulletin (Ndk format)
 """
 
-import Parsers as Par
-import Exploration as Exp
-import MapTools as Map
+from OQCatk import Parsers as Par
+from OQCatk import Exploration as Exp
+from OQCatk import MapTools as Map
 
 #-----------------------------------------------------------------------------------------
 # Import catalogue

--- a/Demos/demo9.py
+++ b/Demos/demo9.py
@@ -2,9 +2,9 @@
 EXAMPLE 9 - Parseing GCMT bulletin (Ndk format)
 """
 
-from OQCatk import Parsers as Par
-from OQCatk import Exploration as Exp
-from OQCatk import MapTools as Map
+import OQCatk.Parsers as Par
+import OQCatk.Exploration as Exp
+import OQCatk.MapTools as Map
 
 #-----------------------------------------------------------------------------------------
 # Import catalogue

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md LICENSE
+
+recursive-include OQCatk/*.*

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -1,0 +1,12 @@
+# Suggested versions for development based on
+# Ubuntu 16.04 stack
+# !! must update pip first! so wheels will be used !!
+
+http://ftp.openquake.org/wheelhouse/linux/py27/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://ftp.openquake.org/wheelhouse/linux/py27/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://ftp.openquake.org/wheelhouse/linux/py27/matplotlib-1.5.3-cp27-cp27mu-manylinux1_x86_64.whl
+http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://ftp.openquake.org/wheelhouse/linux/py27/pyproj-1.9.5.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://ftp.openquake.org/wheelhouse/linux/py27/basemap-1.0.8-cp27-cp27mu-manylinux1_x86_64.whl

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+from setuptools import setup, find_packages
+
+url = "https://github.com/GEMScienceTools/CatalogueTool-Lite"
+
+README = """
+A simplified Python toolkit for earthquake catalogue manipulation and homogenisation
+
+The toolkit consists of 12 main modules:
+
+ * Catalogue - The main module for database manipulation an I/O
+ * Parsers - Ad-hoc parsers for specific catalogues and bulletins (ISC, GCMT...)
+ * Selection - Functions for high-level manipulation of catalogue objects
+ * Exploration - Functions to explore database information and perform basic statistical analysis
+ * Regressor - Utilities for magnitude conversion and catalogue homogenisation
+ * Declusterer - Aftershock/Foreshock removal algorithms
+ * Seismicity - Functions to calculate occurence rates and fit magnitude-frequency distributions
+ * MagRules - Library of magnitude conversion functions
+ * MapTools - Utility to plot earthquake databases on a map
+ * Converters - Utility to convert to other formats
+ * IscWeb - API to download isf catalogues from the ISC web
+ * IscCode - ISC agency code list
+
+"""
+
+setup(
+    name='OQCatk',
+    version='1.0.0',
+    description="""A simplified Python toolkit for earthquake catalogue
+                   manipulation and homogenisation""",
+    long_description=README,
+    url=url,
+    packages=find_packages(exclude=['tests', 'tests.*']),
+    install_requires=[
+        'numpy',
+        'scipy',
+        'matplotlib',
+        'basemap',
+    ],
+    author='GEM Foundation',
+    author_email='hazard@globalquakemodel.org',
+    maintainer='GEM Foundation',
+    maintainer_email='hazard@globalquakemodel.org',
+    classifiers=(
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Education',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: GNU Affero General Public License v3',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Topic :: Scientific/Engineering',
+    ),
+    keywords="seismic hazard",
+    license="AGPL3",
+    platforms=["any"],
+    package_data={"OQCatk": [
+        "README.md", "LICENSE"]},
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ The toolkit consists of 12 main modules:
 
 setup(
     name='OQCatk',
-    version='1.0.0',
+    version='0.1.0',
     description="""A simplified Python toolkit for earthquake catalogue
                    manipulation and homogenisation""",
     long_description=README,
@@ -59,7 +59,7 @@ setup(
     maintainer='GEM Foundation',
     maintainer_email='hazard@globalquakemodel.org',
     classifiers=(
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: GNU Affero General Public License v3',


### PR DESCRIPTION
This PR does the follow
- Adds a `setup.py`, making the library installable via `pip` and `setuptools`
- Fixes imports in demos
- Adds a `.travis.yml` which runs demos on Travis (using requirements in `requirements-py27-linux64.txt`)

Travis has currently some issues and no logs from builds are available. Anyway, build is broken because some demos don't run:

```python
Traceback (most recent call last):
  File "demo5.py", line 31, in <module>
    Sel.MagConvert(Db1,'*',['Ms','MS'],'Mw',MR.MsMw_Scordillis2006)
AttributeError: 'module' object has no attribute 'MsMw_Scordillis2006'
Traceback (most recent call last):
  File "demo6.py", line 24, in <module>
    Db2 = Exp.AreaSelect(Db1,p)
AttributeError: 'module' object has no attribute 'AreaSelect'
Traceback (most recent call last):
  File "demo7.py", line 18, in <module>
    DbP, DbN = Exp.SplitPrime(Db)
AttributeError: 'module' object has no attribute 'SplitPrime'
Traceback (most recent call last):
  File "demo9.py", line 19, in <module>
    Db2 = Exp.AreaSelect(Db,p)
AttributeError: 'module' object has no attribute 'AreaSelect'
```